### PR TITLE
Fix the installation with the new build system

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,3 +11,6 @@ packages = ['statcont']
 [project]
 name = "statcont"
 dynamic = ['version', 'authors', 'dependencies', 'readme', 'description', 'requires-python', 'optional-dependencies', 'license']
+
+[project.scripts]
+statcont = "statcont:main"

--- a/setup.cfg
+++ b/setup.cfg
@@ -78,6 +78,8 @@ python_requires = >=3.9
 install_requires=
    numpy>=1.20
    astropy>=5.0
+   scipy
+   matplotlib
 tests_require =
    pytest-doctestplus>=0.13
    pytest-astropy


### PR DESCRIPTION
This is an attempt to fix two issues with the refactor_install_system branch:

- Add missing dependencies
- Install the `statcont` script

With these two minor fixes, `statcont --help` also works. But I haven't tested the program beyond that.